### PR TITLE
Remove apikey from the ignored parameters list.

### DIFF
--- a/earningscall/api.py
+++ b/earningscall/api.py
@@ -34,7 +34,7 @@ def cache_session() -> CachedSession:
         backend="sqlite",
         cache_control=True,
         use_temp=True,
-        ignored_parameters=['apikey'],
+        ignored_parameters=[],
     )
 
 

--- a/hatch.toml
+++ b/hatch.toml
@@ -33,7 +33,7 @@ dependencies = [
 [envs.lint.scripts]
 typing = "mypy --install-types --non-interactive {args:earningscall tests}"
 style = [
-  "ruff {args:.}",
+  "ruff check {args:.}",
   "black --check --diff {args:.}",
 ]
 fmt = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "earningscall"
-version = "0.0.16"
+version = "0.0.17"
 description = "The EarningsCall Python library provides convenient access to the EarningsCall API.  It includes a pre-defined set of classes for API resources that initialize themselves dynamically from API responses."
 readme = "README.md"
 authors = [

--- a/tests/test_get_sp500_companies_api.py
+++ b/tests/test_get_sp500_companies_api.py
@@ -33,7 +33,7 @@ def test_load_sp500_tickers():
     ##
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == "https://v2.api.earningscall.biz/symbols/sp500.txt?apikey=demo"
-    assert cached_urls() == ["https://v2.api.earningscall.biz/symbols/sp500.txt?apikey=REDACTED"]
+    assert cached_urls() == ["https://v2.api.earningscall.biz/symbols/sp500.txt?apikey=demo"]
     tickers = [ticker_symbol for ticker_symbol in sp500_raw_text.split("\n")]
     assert tickers == ["AAPL", "MSFT", "TSLA"]
     ##
@@ -44,7 +44,7 @@ def test_load_sp500_tickers():
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == "https://v2.api.earningscall.biz/symbols/sp500.txt?apikey=demo"
     urls = cached_urls()
-    assert urls == ["https://v2.api.earningscall.biz/symbols/sp500.txt?apikey=REDACTED"]
+    assert urls == ["https://v2.api.earningscall.biz/symbols/sp500.txt?apikey=demo"]
     tickers = [ticker_symbol for ticker_symbol in sp500_raw_text.split("\n")]
     assert tickers == ["AAPL", "MSFT", "TSLA"]
     ##
@@ -57,6 +57,6 @@ def test_load_sp500_tickers():
     assert len(responses.calls) == 2
     assert responses.calls[0].request.url == "https://v2.api.earningscall.biz/symbols/sp500.txt?apikey=demo"
     assert responses.calls[1].request.url == "https://v2.api.earningscall.biz/symbols/sp500.txt?apikey=demo"
-    assert cached_urls() == ["https://v2.api.earningscall.biz/symbols/sp500.txt?apikey=REDACTED"]
+    assert cached_urls() == ["https://v2.api.earningscall.biz/symbols/sp500.txt?apikey=demo"]
     tickers = [ticker_symbol for ticker_symbol in sp500_raw_text.split("\n")]
     assert tickers == ["AAPL", "MSFT", "TSLA", "NEWCOMPANY"]


### PR DESCRIPTION
When `apikey=demo`, the API will return different results.  If we change apikey to some other value, then the old result from when `apikey=demo` would be returned.  This is incorrect.