### PR TITLE
Add customized retry strategies for different plan types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Release `1.2.0` - 2025-01-27
+
+* Add customized retry strategy for different plan types.
+* Update default retry strategy to use 0.5s base delay and 5 max attempts.
+
 ## Release `1.1.1` - 2025-01-26
 
 * Modify default retry strategy to use 1s base delay and 10 max attempts (necessary for starter plan).

--- a/README.md
+++ b/README.md
@@ -284,8 +284,8 @@ import earningscall
 
 earningscall.retry_strategy = {
     "strategy": "exponential",
-    "base_delay": 1,
-    "max_attempts": 10,
+    "base_delay": 0.5,
+    "max_attempts": 3,
 }
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "earningscall"
-version = "1.1.1"
+version = "1.2.0"
 description = "The EarningsCall Python library provides convenient access to the EarningsCall API.  It includes a pre-defined set of classes for API resources that initialize themselves dynamically from API responses."
 readme = "README.md"
 authors = [{ name = "EarningsCall", email = "dev@earningscall.biz" }]


### PR DESCRIPTION
* Implement plan-specific retry strategies with varying base delays and max attempts
* Update default retry strategy to use 0.5s base delay and 3 max attempts
* Add function to dynamically select retry strategy based on API key
* Update README and version to reflect new retry configuration