### PR TITLE
Add earnings calendar functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Release `1.2.0` - 2025-02-12
+
+* Add `get_calendar` function to get the calendar for a given date.
+
 ## Release `1.1.1` - 2025-01-26
 
 * Modify default retry strategy to use 1s base delay and 10 max attempts (necessary for starter plan).

--- a/README.md
+++ b/README.md
@@ -245,6 +245,19 @@ for company in get_sp500_companies():
     print(f"{company.company_info} -- {company.company_info.sector} -- {company.company_info.industry}")
 ```
 
+## Get Earnings Event Calendar
+
+```python
+from datetime import date
+
+from earningscall import get_calendar
+
+calendar = get_calendar(date(2025, 2, 10))
+
+for event in calendar:
+    print(f"{event.company_name} -- {event.exchange} -- {event.symbol} -- {event.year} -- {event.quarter} -- {event.conference_date}")
+```
+
 
 ## Advanced
 

--- a/earningscall/__init__.py
+++ b/earningscall/__init__.py
@@ -1,10 +1,17 @@
 from typing import Dict, Optional, Union
 
-from earningscall.exports import get_company, get_all_companies, get_sp500_companies
+from earningscall.exports import get_company, get_all_companies, get_sp500_companies, get_calendar
 from earningscall.symbols import Symbols, load_symbols
 
 api_key: Optional[str] = None
 enable_requests_cache: bool = True
 retry_strategy: Optional[Dict[str, Union[str, int, float]]] = None
 
-__all__ = ["get_company", "get_all_companies", "get_sp500_companies", "Symbols", "load_symbols"]
+__all__ = [
+    "get_company",
+    "get_all_companies",
+    "get_sp500_companies",
+    "Symbols",
+    "load_symbols",
+    "get_calendar",
+]

--- a/earningscall/api.py
+++ b/earningscall/api.py
@@ -1,9 +1,9 @@
 import importlib
-import platform
-import urllib.parse
 import logging
 import os
+import platform
 import time
+import urllib.parse
 from importlib.metadata import PackageNotFoundError
 from typing import Dict, Optional, Union
 
@@ -169,7 +169,18 @@ def do_get(
     return response  # Return the last response if all retries failed
 
 
-def get_events(exchange: str, symbol: str):
+def get_calendar_api_operation(year: int, month: int, day: int) -> dict:
+    params = {
+        "year": str(year),
+        "month": str(month),
+        "day": str(day),
+    }
+    response = do_get("calendar", params=params)
+    response.raise_for_status()
+    return response.json()
+
+
+def get_events(exchange: str, symbol: str) -> Optional[dict]:
     params = {
         "exchange": exchange,
         "symbol": symbol,

--- a/earningscall/calendar.py
+++ b/earningscall/calendar.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional
+
+from dataclasses_json import config
+from dataclasses_json import dataclass_json
+from marshmallow import fields
+
+
+@dataclass_json
+@dataclass
+class CalendarEvent:
+    """
+    CalendarEvent
+    """
+
+    company_name: str
+    exchange: str
+    symbol: str
+    year: int
+    quarter: int
+    transcript_ready: bool
+    conference_date: Optional[datetime] = field(
+        default=None,
+        metadata=config(
+            encoder=lambda date: date.isoformat() if date else None,
+            decoder=lambda date: datetime.fromisoformat(date) if date else None,
+            mm_field=fields.DateTime(format="iso"),
+        ),
+    )

--- a/earningscall/exports.py
+++ b/earningscall/exports.py
@@ -1,7 +1,14 @@
-from typing import Optional, Iterator
+import datetime
+from datetime import date, timedelta
+from typing import List, Optional, Iterator
 
-from earningscall.api import get_sp500_companies_txt_file
+import requests
+
+from earningscall import api
+from earningscall.api import get_sp500_companies_txt_file, is_demo_account
+from earningscall.calendar import CalendarEvent
 from earningscall.company import Company
+from earningscall.errors import InsufficientApiAccessError
 from earningscall.symbols import get_symbols
 
 
@@ -43,3 +50,37 @@ def get_sp500_companies() -> Iterator[Company]:
         company_info = get_symbols().lookup_company(ticker_symbol)
         if company_info:
             yield Company(company_info=company_info)
+
+
+def get_calendar(input_date: date) -> List[CalendarEvent]:
+    """
+    Get the earnings event calendar for a given input date.
+
+    :param date input_date: The date to get the calendar for.
+
+    :return: A list of CalendarEvent objects.
+    """
+    if not input_date:
+        raise ValueError("Date is required")
+    if isinstance(input_date, datetime.datetime):
+        input_date = input_date.date()
+    if not isinstance(input_date, date):
+        raise ValueError("Date must be a date object")
+    if input_date < date(2018, 1, 1):
+        raise ValueError("input_date must be greater than or equal to 2018-01-01")
+    # Check if input_date is greater than 30 days from today
+    if input_date > datetime.datetime.now().date() + timedelta(days=30):
+        raise ValueError("input_date must be less than 30 days from today")
+    if is_demo_account() and input_date != date(2025, 1, 10):
+        raise InsufficientApiAccessError(
+            f"\"{input_date}\" requires an API Key for access.  To get your API Key,"
+            f" see: https://earningscall.biz/api-pricing"
+        )
+    try:
+        json_data = api.get_calendar_api_operation(input_date.year, input_date.month, input_date.day)
+        return [CalendarEvent.from_dict(event) for event in json_data]  # type: ignore
+    except requests.exceptions.HTTPError as error:
+        if error.response.status_code == 404:
+            # Calendar Date not found, simply return an empty list
+            return []
+        raise error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "earningscall"
-version = "1.1.1"
+version = "1.2.0"
 description = "The EarningsCall Python library provides convenient access to the EarningsCall API.  It includes a pre-defined set of classes for API resources that initialize themselves dynamically from API responses."
 readme = "README.md"
 authors = [{ name = "EarningsCall", email = "dev@earningscall.biz" }]

--- a/scripts/get_calendar.py
+++ b/scripts/get_calendar.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+import earningscall  # noqa: F401
+
+from earningscall import get_calendar
+
+
+# TODO: Set your API key here:
+# earningscall.api_key = "YOUR API KEY HERE"
+
+date = datetime(2025, 1, 10)
+
+events = get_calendar(date)
+
+for event in events:
+    print(f"{event.company_name} - Q{event.quarter} {event.year} on: {event.conference_date.astimezone().isoformat()} Transcript Ready: {event.transcript_ready}")

--- a/tests/data/get-calendar-500-error.yaml
+++ b/tests/data/get-calendar-500-error.yaml
@@ -1,0 +1,14 @@
+responses:
+- response:
+    auto_calculate_content_length: false
+    body: ''
+    content_type: text/plain
+    headers:
+      Via: 1.1 1cae0bb0106fc058447f3b32dee7b228.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id: GJG7c5roSXmd3WXEWTNzyrl8VN9fWmIm3OR8oYxEZg8bWpoiZE6XvA==
+      X-Amz-Cf-Pop: IAH50-C4
+      X-Cache: FunctionGeneratedResponse from cloudfront
+      X-Plan-Name: demo
+    method: GET
+    status: 500
+    url: https://v2.api.earningscall.biz/calendar?apikey=XXXXXXXXXXX&year=2020&month=1&day=1

--- a/tests/data/get-calendar-not-found-response.yaml
+++ b/tests/data/get-calendar-not-found-response.yaml
@@ -1,0 +1,14 @@
+responses:
+- response:
+    auto_calculate_content_length: false
+    body: ''
+    content_type: text/plain
+    headers:
+      Via: 1.1 1cae0bb0106fc058447f3b32dee7b228.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id: GJG7c5roSXmd3WXEWTNzyrl8VN9fWmIm3OR8oYxEZg8bWpoiZE6XvA==
+      X-Amz-Cf-Pop: IAH50-C4
+      X-Cache: FunctionGeneratedResponse from cloudfront
+      X-Plan-Name: starter
+    method: GET
+    status: 404
+    url: https://v2.api.earningscall.biz/calendar?apikey=XXXXXXXXXXX&year=2018&month=1&day=1

--- a/tests/data/get-calendar-successful-response.yaml
+++ b/tests/data/get-calendar-successful-response.yaml
@@ -1,0 +1,62 @@
+responses:
+- response:
+    auto_calculate_content_length: false
+    body: '[{"exchange": "NASDAQ", "symbol": "MPAA", "year": 2025, "quarter": 3, "conference_date":
+      "2025-02-10T13:00:00.000-05:00", "company_name": "Motorcar Parts of America,
+      Inc.", "transcript_ready": true}, {"exchange": "NASDAQ", "symbol": "SPSC", "year":
+      2024, "quarter": 4, "conference_date": "2025-02-10T16:30:00-05:00", "company_name":
+      "SPS Commerce, Inc.", "transcript_ready": true}, {"exchange": "NASDAQ", "symbol":
+      "RICK", "year": 2025, "quarter": 1, "conference_date": "2025-02-10T16:30:00-05:00",
+      "company_name": "RCI Hospitality Holdings, Inc.", "transcript_ready": true},
+      {"exchange": "NASDAQ", "symbol": "ALAB", "year": 2024, "quarter": 4, "conference_date":
+      "2025-02-10T16:30:00-05:00", "company_name": "Astera Labs, Inc.", "transcript_ready":
+      true}, {"exchange": "NASDAQ", "symbol": "PETS", "year": 2025, "quarter": 3,
+      "conference_date": "2025-02-10T16:30:00-05:00", "company_name": "PetMed Express,
+      Inc.", "transcript_ready": true}, {"exchange": "NASDAQ", "symbol": "XAIR", "year":
+      2025, "quarter": 3, "conference_date": "2025-02-10T16:30:00-05:00", "company_name":
+      "Beyond Air, Inc.", "transcript_ready": true}, {"exchange": "NASDAQ", "symbol":
+      "BLFS", "year": 2024, "quarter": 4, "conference_date": "2025-02-10T16:30:00.000-05:00",
+      "company_name": "BioLife Solutions, Inc.", "transcript_ready": true}, {"exchange":
+      "NASDAQ", "symbol": "VRTX", "year": 2024, "quarter": 4, "conference_date": "2025-02-10T16:30:00.000-05:00",
+      "company_name": "Vertex Pharmaceuticals Incorporated", "transcript_ready": true},
+      {"exchange": "NYSE", "symbol": "TAK", "year": 2025, "quarter": 1, "conference_date":
+      "2025-02-10T16:30:00-05:00", "company_name": "Takeda Pharmaceutical Company
+      Limited", "transcript_ready": true}, {"exchange": "OTC", "symbol": "PRKA", "year":
+      2025, "quarter": 1, "conference_date": "2025-02-10T16:30:00.000-05:00", "company_name":
+      "Parks! America Inc", "transcript_ready": true}, {"exchange": "NASDAQ", "symbol":
+      "AMKR", "year": 2024, "quarter": 4, "conference_date": "2025-02-10T17:00:00.000-05:00",
+      "company_name": "Amkor Technology, Inc.", "transcript_ready": true}, {"exchange":
+      "NASDAQ", "symbol": "MITK", "year": 2025, "quarter": 1, "conference_date": "2025-02-10T17:00:00-05:00",
+      "company_name": "Mitek Systems, Inc.", "transcript_ready": true}, {"exchange":
+      "NYSE", "symbol": "SLQT", "year": 2025, "quarter": 2, "conference_date": "2025-02-10T17:00:00-05:00",
+      "company_name": "SelectQuote, Inc.", "transcript_ready": true}, {"exchange":
+      "NYSE", "symbol": "NGL", "year": 2025, "quarter": 3, "conference_date": "2025-02-10T16:00:00-06:00",
+      "company_name": "NGL Energy Partners LP", "transcript_ready": true}, {"exchange":
+      "NASDAQ", "symbol": "LSCC", "year": 2024, "quarter": 4, "conference_date": "2025-02-10T17:00:00-05:00",
+      "company_name": "Lattice Semiconductor Corporation", "transcript_ready": true},
+      {"exchange": "TSX", "symbol": "CVO", "year": 2025, "quarter": 3, "conference_date":
+      "2025-02-10T17:00:00-05:00", "company_name": "Coveo Solutions Inc.", "transcript_ready":
+      true}, {"exchange": "NYSE", "symbol": "INSP", "year": 2024, "quarter": 4, "conference_date":
+      "2025-02-10T17:00:00-05:00", "company_name": "Inspire Medical Systems, Inc.",
+      "transcript_ready": true}, {"exchange": "NASDAQ", "symbol": "CMCO", "year":
+      2025, "quarter": 3, "conference_date": "2025-02-10T17:00:00-05:00", "company_name":
+      "Columbus McKinnon Corporation", "transcript_ready": true}, {"exchange": "NASDAQ",
+      "symbol": "HLIT", "year": 2024, "quarter": 4, "conference_date": "2025-02-10T14:00:00-08:00",
+      "company_name": "Harmonic Inc.", "transcript_ready": true}, {"exchange": "NYSE",
+      "symbol": "SSD", "year": 2024, "quarter": 4, "conference_date": "2025-02-10T17:00:00-05:00",
+      "company_name": "Simpson Manufacturing Company, Inc.", "transcript_ready": true}]'
+    content_type: text/plain
+    headers:
+      Cache-Control: public, max-age=500
+      ETag: W/"ff349ae06e2284df57d342fd9e3c9d4b"
+      Last-Modified: Wed, 12 Feb 2025 15:44:12 GMT
+      Transfer-Encoding: chunked
+      Vary: accept-encoding
+      Via: 1.1 dab9621fb9e60d4beae799f308450f86.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id: o-89nbe8YAinJi-F0rXkAr8qIUAcTkW6Mmvk4vQeDH-9ob1MZ7QVfg==
+      X-Amz-Cf-Pop: IAH50-C4
+      X-Cache: Miss from cloudfront
+      x-amz-server-side-encryption: AES256
+    method: GET
+    status: 200
+    url: https://v2.api.earningscall.biz/calendar?apikey=XXXXXXXXXXX&year=2025&month=2&day=10

--- a/tests/test_download_audio_files.py
+++ b/tests/test_download_audio_files.py
@@ -14,14 +14,6 @@ from earningscall.symbols import CompanyInfo, clear_symbols
 from earningscall.utils import data_path
 
 
-# Uncomment and run following code to generate msft-transcript-response.yaml file
-#
-# from responses import _recorder
-# @_recorder.record(file_path="meta-q3-2024-not-found.yaml")
-# def test_save_symbols_v1():
-#     requests.get("https://v2.api.alpha.earningscall.biz/audio?apikey=brocktest&exchange=NASDAQ&symbol=META&year=2024&quarter=3")
-
-
 @pytest.fixture(autouse=True)
 def run_before_and_after_tests():
     """Fixture to execute asserts before and after a test is run"""

--- a/tests/test_get_calendar.py
+++ b/tests/test_get_calendar.py
@@ -1,0 +1,108 @@
+from datetime import datetime, date, timedelta
+
+import pytest
+import requests
+import responses
+
+import earningscall
+from earningscall import get_calendar
+from earningscall.api import purge_cache
+from earningscall.errors import InsufficientApiAccessError
+from earningscall.utils import data_path
+
+
+# Uncomment and run following code to generate msft-transcript-response.yaml file
+#
+
+# import earningscall
+# @_recorder.record(file_path="data/get-calendar-not-found-response.yaml")
+# def test_save_symbols_v1():
+#     requests.get("https://v2.api.earningscall.biz/calendar?apikey=demo&year=1980&month=1&day=1")
+
+
+@pytest.fixture(autouse=True)
+def run_before_and_after_tests():
+    """Fixture to execute asserts before and after a test is run"""
+    # Setup
+    earningscall.api_key = None
+    earningscall.retry_strategy = {
+        "strategy": "exponential",
+        "base_delay": 0.01,
+        "max_attempts": 3,
+    }
+    purge_cache()
+    yield  # this is where the testing happens
+    # Teardown
+    earningscall.api_key = None
+
+
+@responses.activate
+def test_get_calendar_invalid_inputs():
+    with pytest.raises(ValueError):
+        get_calendar(None)
+    with pytest.raises(ValueError):
+        get_calendar("2025-02-10")
+    with pytest.raises(ValueError):
+        get_calendar(123456)
+    with pytest.raises(ValueError):
+        get_calendar(date(2017, 12, 31))
+    with pytest.raises(ValueError):
+        get_calendar(datetime.now() + timedelta(days=31))
+
+
+@responses.activate
+def test_get_non_demo_date():
+    with pytest.raises(InsufficientApiAccessError):
+        get_calendar(date(2020, 1, 1))
+
+
+@responses.activate
+def test_get_calendar_success():
+    earningscall.api_key = "XXXXXXXXXXX"
+    responses._add_from_file(file_path=data_path("get-calendar-successful-response.yaml"))
+    calendar = get_calendar(date(2025, 2, 10))
+    assert len(calendar) == 20
+    assert calendar[0].exchange == "NASDAQ"
+    assert calendar[0].symbol == "MPAA"
+    assert calendar[0].year == 2025
+    assert calendar[0].quarter == 3
+    assert calendar[0].conference_date.year == 2025
+    assert calendar[0].conference_date.month == 2
+    assert calendar[0].conference_date.day == 10
+    assert calendar[0].transcript_ready
+    assert calendar[0].company_name == "Motorcar Parts of America, Inc."
+
+
+@responses.activate
+def test_get_calendar_success_with_datetime():
+    earningscall.api_key = "XXXXXXXXXXX"
+    responses._add_from_file(file_path=data_path("get-calendar-successful-response.yaml"))
+    calendar = get_calendar(datetime(2025, 2, 10))
+    assert len(calendar) == 20
+    assert calendar[0].exchange == "NASDAQ"
+    assert calendar[0].symbol == "MPAA"
+    assert calendar[0].year == 2025
+    assert calendar[0].quarter == 3
+    assert calendar[0].conference_date.year == 2025
+    assert calendar[0].conference_date.month == 2
+    assert calendar[0].conference_date.day == 10
+    assert calendar[0].transcript_ready
+    assert calendar[0].company_name == "Motorcar Parts of America, Inc."
+
+
+@responses.activate
+def test_get_calendar_server_error():
+    earningscall.api_key = "XXXXXXXXXXX"
+    responses._add_from_file(file_path=data_path("get-calendar-500-error.yaml"))
+    with pytest.raises(requests.exceptions.HTTPError):
+        get_calendar(date(2020, 1, 1))
+    # calendar = get_calendar(date(2020, 1, 1))
+    # assert len(calendar) == 0
+
+
+@responses.activate
+def test_get_calendar_not_found():
+    earningscall.api_key = "XXXXXXXXXXX"
+    responses._add_from_file(file_path=data_path("get-calendar-not-found-response.yaml"))
+    calendar = get_calendar(date(2018, 1, 1))
+    assert len(calendar) == 0


### PR DESCRIPTION
- Implement get_calendar() method to retrieve earnings call calendar events
- Create CalendarEvent dataclass to represent calendar event details
- Add new API endpoint for fetching calendar events by date
- Update __init__.py to expose get_calendar() function
- Include example script for calendar event retrieval
- Add corresponding test for calendar functionality