### PR TITLE
Add slide deck download functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Release `1.3.0` - 2025-07-17
+
+* Add `download_slide_deck` function to the `Company` class.
+
 ## Release `1.2.1` - 2025-04-04
 
 * Bugfix: handle case where Q&A section is missing from the transcript for level 4 transcription.

--- a/README.md
+++ b/README.md
@@ -208,6 +208,16 @@ print("Downloading audio file for Apple Inc. Q3 2021...")
 audio_file = company.download_audio_file(year=2021, quarter=3, file_name="Apple Q3 2021.mp3")
 ```
 
+## Download Slide Deck
+
+```python
+from earningscall import get_company
+
+company = get_company("aapl")  # Lookup Apple, Inc by its ticker symbol, "AAPL"
+
+slide_deck = company.download_slide_deck(year=2021, quarter=3, file_name="Apple Q3 2021 Slides.pdf")
+```
+
 ## Get Earnings Event Calendar
 
 ```python

--- a/README.md
+++ b/README.md
@@ -205,7 +205,8 @@ from earningscall import get_company
 company = get_company("aapl")  # Lookup Apple, Inc by its ticker symbol, "AAPL"
 
 print("Downloading audio file for Apple Inc. Q3 2021...")
-audio_file = company.download_audio_file(year=2021, quarter=3, file_name="Apple Q3 2021.mp3")
+audio_file = company.download_audio_file(year=2021, quarter=3, file_name="Apple-Q3-2021.mp3")
+print(f"Downloaded audio file to: {audio_file}")
 ```
 
 ## Download Slide Deck
@@ -215,7 +216,8 @@ from earningscall import get_company
 
 company = get_company("aapl")  # Lookup Apple, Inc by its ticker symbol, "AAPL"
 
-slide_deck = company.download_slide_deck(year=2021, quarter=3, file_name="Apple Q3 2021 Slides.pdf")
+slide_deck_filename = company.download_slide_deck(year=2021, quarter=3, file_name="Apple-Q3-2021-Slides.pdf")
+print(f"Downloaded slide deck to: {slide_deck_filename}")
 ```
 
 ## Get Earnings Event Calendar

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "earningscall"
-version = "1.2.1"
+version = "1.3.0"
 description = "The EarningsCall Python library provides convenient access to the EarningsCall API.  It includes a pre-defined set of classes for API resources that initialize themselves dynamically from API responses."
 readme = "README.md"
 authors = [{ name = "EarningsCall", email = "dev@earningscall.biz" }]

--- a/scripts/download_slides.py
+++ b/scripts/download_slides.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+Script to download slides for a given company and quarter
+"""
+
+import earningscall
+
+
+def test_slides_api():
+    """Test the new slides API functionality"""
+
+    # Get a company
+    company = earningscall.get_company("MSFT")
+    if not company:
+        print("Could not find MSFT company")
+        return
+
+    print(f"Testing slides API for {company.company_info.name}")
+
+    try:
+        # Try to download slides for Q1 2025 (using demo data)
+        slide_file = company.download_slide_deck(year=2025, quarter=1)
+        if slide_file:
+            print(f"Successfully downloaded slides: {slide_file}")
+        else:
+            print("No slides available for the requested quarter")
+
+    except Exception as e:
+        print(f"Error downloading slides: {e}")
+        # This is expected for demo account or if slides aren't available
+
+
+if __name__ == "__main__":
+    test_slides_api()

--- a/tests/data/meta-q3-2024-slides-not-authorized.yaml
+++ b/tests/data/meta-q3-2024-slides-not-authorized.yaml
@@ -1,0 +1,15 @@
+responses:
+- response:
+    auto_calculate_content_length: false
+    body: ''
+    content_type: text/plain
+    headers:
+      Transfer-Encoding: chunked
+      Via: 1.1 dda997f5acee0f79dcf70db4a17d82f6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id: hHQoX1-pbWB6rw1QN1G5grABhjXtX_cdjfpnR4lkIU4ypiZRBRk4kQ==
+      X-Amz-Cf-Pop: IAH50-C4
+      X-Cache: Error from cloudfront
+      X-Plan-Name: basic
+    method: GET
+    status: 403
+    url: https://v2.api.earningscall.biz/slides?apikey=foobar&exchange=NASDAQ&symbol=META&year=2024&quarter=3 

--- a/tests/data/meta-q3-2024-slides-not-found.yaml
+++ b/tests/data/meta-q3-2024-slides-not-found.yaml
@@ -1,0 +1,16 @@
+responses:
+- response:
+    auto_calculate_content_length: false
+    body: '<?xml version="1.0" encoding="UTF-8"?>
+
+      <Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Key>404.html</Key><RequestId>C1SFD1W2WXC0JHHC</RequestId><HostId>Fp+yajCTsxImKV1EaTFJ7C9i+jpeNUy1t4FcY8Iq0B3Z8js6baJPx4qhYaTECecl8jiD85Odqoc=</HostId></Error>'
+    content_type: text/plain
+    headers:
+      Transfer-Encoding: chunked
+      Via: 1.1 dda997f5acee0f79dcf70db4a17d82f6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id: hHQoX1-pbWB6rw1QN1G5grABhjXtX_cdjfpnR4lkIU4ypiZRBRk4kQ==
+      X-Amz-Cf-Pop: IAH50-C4
+      X-Cache: Error from cloudfront
+    method: GET
+    status: 404
+    url: https://v2.api.earningscall.biz/slides?apikey=foobar&exchange=NASDAQ&symbol=META&year=2024&quarter=3 

--- a/tests/data/meta-q3-2024-slides-other-error.yaml
+++ b/tests/data/meta-q3-2024-slides-other-error.yaml
@@ -1,0 +1,15 @@
+responses:
+- response:
+    auto_calculate_content_length: false
+    body: ''
+    content_type: text/plain
+    headers:
+      Transfer-Encoding: chunked
+      Via: 1.1 dda997f5acee0f79dcf70db4a17d82f6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id: hHQoX1-pbWB6rw1QN1G5grABhjXtX_cdjfpnR4lkIU4ypiZRBRk4kQ==
+      X-Amz-Cf-Pop: IAH50-C4
+      X-Cache: Error from cloudfront
+      X-Plan-Name: basic
+    method: GET
+    status: 500
+    url: https://v2.api.earningscall.biz/slides?apikey=foobar&exchange=NASDAQ&symbol=META&year=2024&quarter=3 

--- a/tests/data/msft-q1-2022-slide-deck-short-clip.yaml
+++ b/tests/data/msft-q1-2022-slide-deck-short-clip.yaml
@@ -1,0 +1,62 @@
+responses:
+- response:
+    auto_calculate_content_length: false
+    body: '%PDF-1.4
+1 0 obj
+<<
+/Type /Catalog
+/Pages 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Kids [3 0 R]
+/Count 1
+>>
+endobj
+3 0 obj
+<<
+/Type /Page
+/Parent 2 0 R
+/MediaBox [0 0 612 792]
+/Contents 4 0 R
+>>
+endobj
+4 0 obj
+<<
+/Length 44
+>>
+stream
+BT
+/F1 12 Tf
+100 700 Td
+(Test Slide Deck) Tj
+ET
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000208 00000 n 
+trailer
+<<
+/Size 5
+/Root 1 0 R
+>>
+startxref
+299
+%%EOF'
+    content_type: application/pdf
+    headers:
+      Transfer-Encoding: chunked
+      Via: 1.1 dda997f5acee0f79dcf70db4a17d82f6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id: hHQoX1-pbWB6rw1QN1G5grABhjXtX_cdjfpnR4lkIU4ypiZRBRk4kQ==
+      X-Amz-Cf-Pop: IAH50-C4
+      X-Cache: Hit from cloudfront
+    method: GET
+    status: 200
+    url: https://v2.api.earningscall.biz/slides?apikey=demo&exchange=NASDAQ&symbol=MSFT&year=2022&quarter=1 

--- a/tests/test_download_slide_decks.py
+++ b/tests/test_download_slide_decks.py
@@ -1,0 +1,147 @@
+import os
+
+import pytest
+import responses
+from requests import HTTPError
+
+import earningscall
+from earningscall import get_company
+from earningscall.api import purge_cache
+from earningscall.company import Company
+from earningscall.errors import InsufficientApiAccessError
+from earningscall.event import EarningsEvent
+from earningscall.symbols import CompanyInfo, clear_symbols
+from earningscall.utils import data_path
+
+
+@pytest.fixture(autouse=True)
+def run_before_and_after_tests():
+    """Fixture to execute asserts before and after a test is run"""
+    # Setup: fill with any logic you want
+    earningscall.api_key = None
+    earningscall.retry_strategy = {
+        "strategy": "exponential",
+        "base_delay": 0.001,
+        "max_attempts": 3,
+    }
+    purge_cache()
+    clear_symbols()
+    yield  # this is where the testing happens
+    # Teardown : fill with any logic you want
+    earningscall.api_key = None
+
+
+@responses.activate
+def test_download_slide_deck():
+    ##
+    responses._add_from_file(file_path=data_path("symbols-v2.yaml"))
+    responses._add_from_file(file_path=data_path("msft-q1-2022-slide-deck-short-clip.yaml"))
+    responses._add_from_file(file_path=data_path("msft-company-events.yaml"))
+    ##
+    company = get_company("msft")
+    file_name = company.download_slide_deck(year=2022, quarter=1)
+    #
+    assert os.path.exists(file_name)
+    assert os.path.getsize(file_name) > 0
+    # Check that it's a PDF file (starts with %PDF)
+    with open(file_name, 'rb') as f:
+        assert f.read(4) == b'%PDF'
+    os.unlink(file_name)
+
+
+@responses.activate
+def test_download_slide_deck_event():
+    ##
+    responses._add_from_file(file_path=data_path("symbols-v2.yaml"))
+    responses._add_from_file(file_path=data_path("msft-q1-2022-slide-deck-short-clip.yaml"))
+    responses._add_from_file(file_path=data_path("msft-company-events.yaml"))
+    ##
+    company = get_company("msft")
+    file_name = company.download_slide_deck(event=EarningsEvent(year=2022, quarter=1))
+    #
+    assert os.path.exists(file_name)
+    assert os.path.getsize(file_name) > 0
+    # Check that it's a PDF file (starts with %PDF)
+    with open(file_name, 'rb') as f:
+        assert f.read(4) == b'%PDF'
+    os.unlink(file_name)
+
+
+@responses.activate
+def test_download_slide_deck_missing_params_raises_value_error():
+    ##
+    responses._add_from_file(file_path=data_path("symbols-v2.yaml"))
+    ##
+    company = get_company("msft")
+    with pytest.raises(ValueError):
+        company.download_slide_deck()
+    with pytest.raises(ValueError):
+        company.download_slide_deck(year=2023)
+    with pytest.raises(ValueError):
+        company.download_slide_deck(quarter=1)
+    with pytest.raises(ValueError):
+        company.download_slide_deck(quarter=0)
+    with pytest.raises(ValueError):
+        company.download_slide_deck(year=2023, quarter=5)
+    ##
+    invalid_company = Company(company_info=CompanyInfo())
+    slide_deck = invalid_company.download_slide_deck(year=2023, quarter=1)
+    ##
+    assert slide_deck is None
+
+
+@responses.activate
+def test_download_slide_deck_missing_from_server():
+    ##
+    earningscall.api_key = "foobar"  # Set to a bogus API Key.
+    responses._add_from_file(file_path=data_path("symbols-v2.yaml"))
+    responses._add_from_file(file_path=data_path("meta-q3-2024-slides-not-found.yaml"))
+    ##
+    company = get_company("meta")
+    output_file = company.download_slide_deck(year=2024, quarter=3)
+    ##
+    assert output_file is None
+
+
+@responses.activate
+def test_download_slide_deck_not_authorized():
+    ##
+    earningscall.api_key = "foobar"  # Set to a bogus API Key.
+    responses._add_from_file(file_path=data_path("symbols-v2.yaml"))
+    responses._add_from_file(file_path=data_path("meta-q3-2024-slides-not-authorized.yaml"))
+    ##
+    company = get_company("meta")
+    with pytest.raises(InsufficientApiAccessError):
+        company.download_slide_deck(year=2024, quarter=3)
+
+
+@responses.activate
+def test_download_slide_deck_500_error():
+    ##
+    earningscall.api_key = "foobar"  # Set to a bogus API Key.
+    responses._add_from_file(file_path=data_path("symbols-v2.yaml"))
+    responses._add_from_file(file_path=data_path("meta-q3-2024-slides-other-error.yaml"))
+    ##
+    company = get_company("meta")
+    with pytest.raises(HTTPError):
+        company.download_slide_deck(year=2024, quarter=3)
+
+
+@responses.activate
+def test_download_slide_deck_custom_filename():
+    ##
+    responses._add_from_file(file_path=data_path("symbols-v2.yaml"))
+    responses._add_from_file(file_path=data_path("msft-q1-2022-slide-deck-short-clip.yaml"))
+    responses._add_from_file(file_path=data_path("msft-company-events.yaml"))
+    ##
+    company = get_company("msft")
+    custom_filename = "test_custom_slides.pdf"
+    file_name = company.download_slide_deck(year=2022, quarter=1, file_name=custom_filename)
+    #
+    assert file_name == custom_filename
+    assert os.path.exists(file_name)
+    assert os.path.getsize(file_name) > 0
+    # Check that it's a PDF file (starts with %PDF)
+    with open(file_name, 'rb') as f:
+        assert f.read(4) == b'%PDF'
+    os.unlink(file_name)


### PR DESCRIPTION
- Implemented `download_slide_deck` method in both `api.py` and `Company` class to facilitate downloading slide decks for specified companies, years, and quarters.
- Added error handling for missing parameters and API access issues.
- Created a new script `download_slides.py` to test the slide deck download functionality.
- Developed comprehensive tests for the slide deck download feature, including various scenarios and edge cases.
- Introduced YAML files for simulating API responses in tests.