### PR TITLE
Release 1.3.2: Bugfix for Datetime parse error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Release `1.3.2` - 2025-07-25
+
+* Bugfix: handle case where conference date has a 'Z' UTC suffix, which fails on Python 3.10 and below.
+
 ## Release `1.3.1` - 2025-07-18
 
 * Update README.md with new slide deck download example.

--- a/earningscall/event.py
+++ b/earningscall/event.py
@@ -15,8 +15,8 @@ def _parse_conference_date(date_str: str) -> Optional[datetime]:
     if not date_str:
         return None
     # Handle 'Z' suffix by converting to '+00:00' for UTC
-    # if date_str.endswith('Z'):
-    #     date_str = date_str[:-1] + '+00:00'
+    if date_str.endswith('Z'):
+        date_str = date_str[:-1] + '+00:00'
     return datetime.fromisoformat(date_str)
 
 

--- a/earningscall/event.py
+++ b/earningscall/event.py
@@ -10,6 +10,16 @@ from marshmallow import fields
 log = logging.getLogger(__file__)
 
 
+def _parse_conference_date(date_str: str) -> Optional[datetime]:
+    """Parse conference date string, handling both timezone offsets and 'Z' UTC suffix."""
+    if not date_str:
+        return None
+    # Handle 'Z' suffix by converting to '+00:00' for UTC
+    if date_str.endswith('Z'):
+        date_str = date_str[:-1] + '+00:00'
+    return datetime.fromisoformat(date_str)
+
+
 @dataclass_json
 @dataclass
 class EarningsEvent:
@@ -23,7 +33,7 @@ class EarningsEvent:
         default=None,
         metadata=config(
             encoder=lambda date: date.isoformat() if date else None,
-            decoder=lambda date: datetime.fromisoformat(date) if date else None,
+            decoder=lambda date: _parse_conference_date(date),
             mm_field=fields.DateTime(format="iso"),
         ),
     )

--- a/earningscall/event.py
+++ b/earningscall/event.py
@@ -15,8 +15,8 @@ def _parse_conference_date(date_str: str) -> Optional[datetime]:
     if not date_str:
         return None
     # Handle 'Z' suffix by converting to '+00:00' for UTC
-    if date_str.endswith('Z'):
-        date_str = date_str[:-1] + '+00:00'
+    # if date_str.endswith('Z'):
+    #     date_str = date_str[:-1] + '+00:00'
     return datetime.fromisoformat(date_str)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "earningscall"
-version = "1.3.1"
+version = "1.3.2"
 description = "The EarningsCall Python library provides convenient access to the EarningsCall API.  It includes a pre-defined set of classes for API resources that initialize themselves dynamically from API responses."
 readme = "README.md"
 authors = [{ name = "EarningsCall", email = "dev@earningscall.biz" }]

--- a/tests/test_earnings_event.py
+++ b/tests/test_earnings_event.py
@@ -35,9 +35,7 @@ def test_date_field_deserialization():
     )
     assert earnings_event.year == 2024
     assert earnings_event.quarter == 1
-    assert earnings_event.conference_date == datetime.datetime.fromisoformat(
-        "2024-04-28T15:00:00.000-05:00"
-    )
+    assert earnings_event.conference_date == datetime.datetime.fromisoformat("2024-04-28T15:00:00.000-05:00")
 
 
 def test_date_field_deserialization_with_z_suffix():

--- a/tests/test_earnings_event.py
+++ b/tests/test_earnings_event.py
@@ -1,6 +1,6 @@
 import datetime
 
-from earningscall.event import EarningsEvent
+from earningscall.event import EarningsEvent, _parse_conference_date
 
 
 def test_basic_object_creation():
@@ -33,15 +33,15 @@ def test_date_field_deserialization():
             "conference_date": "2024-04-28T15:00:00.000-05:00",
         }
     )
-    #
     assert earnings_event.year == 2024
     assert earnings_event.quarter == 1
-    assert earnings_event.conference_date == datetime.datetime.fromisoformat("2024-04-28T15:00:00.000-05:00")
-    assert earnings_event.conference_date.isoformat() == "2024-04-28T15:00:00-05:00"
+    assert earnings_event.conference_date == datetime.datetime.fromisoformat(
+        "2024-04-28T15:00:00.000-05:00"
+    )
 
 
 def test_date_field_deserialization_with_z_suffix():
-    """Test that the 'Z' UTC suffix is properly handled."""
+    """Test that the date parser correctly handles 'Z' UTC suffix"""
     earnings_event = EarningsEvent.from_dict(
         {
             "year": 2021,
@@ -51,7 +51,25 @@ def test_date_field_deserialization_with_z_suffix():
     )
     assert earnings_event.year == 2021
     assert earnings_event.quarter == 1
-    # Verify the date was parsed correctly as UTC
     expected_date = datetime.datetime.fromisoformat("2021-01-25T13:30:00.000+00:00")
     assert earnings_event.conference_date == expected_date
-    assert earnings_event.conference_date.tzinfo is not None  # Should have timezone info
+
+
+def test_parse_conference_date_with_none():
+    """Test that _parse_conference_date properly handles None input"""
+    result = _parse_conference_date(None)
+    assert result is None
+
+
+def test_earnings_event_from_dict_with_none_conference_date():
+    """Test that EarningsEvent.from_dict works when conference_date is None"""
+    earnings_event = EarningsEvent.from_dict(
+        {
+            "year": 2024,
+            "quarter": 2,
+            "conference_date": None,
+        }
+    )
+    assert earnings_event.year == 2024
+    assert earnings_event.quarter == 2
+    assert earnings_event.conference_date is None

--- a/tests/test_earnings_event.py
+++ b/tests/test_earnings_event.py
@@ -38,3 +38,20 @@ def test_date_field_deserialization():
     assert earnings_event.quarter == 1
     assert earnings_event.conference_date == datetime.datetime.fromisoformat("2024-04-28T15:00:00.000-05:00")
     assert earnings_event.conference_date.isoformat() == "2024-04-28T15:00:00-05:00"
+
+
+def test_date_field_deserialization_with_z_suffix():
+    """Test that the 'Z' UTC suffix is properly handled."""
+    earnings_event = EarningsEvent.from_dict(
+        {
+            "year": 2021,
+            "quarter": 1,
+            "conference_date": "2021-01-25T13:30:00.000Z",
+        }
+    )
+    assert earnings_event.year == 2021
+    assert earnings_event.quarter == 1
+    # Verify the date was parsed correctly as UTC
+    expected_date = datetime.datetime.fromisoformat("2021-01-25T13:30:00.000+00:00")
+    assert earnings_event.conference_date == expected_date
+    assert earnings_event.conference_date.tzinfo is not None  # Should have timezone info


### PR DESCRIPTION
Fix conference date parsing for 'Z' UTC suffix

Issue: https://github.com/EarningsCall/earningscall-python/issues/36

Example error:
```
ValueError: Invalid isoformat string: '2021-01-25T13:30:00.000Z'
```