### PR TITLE
chore: upgrade GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.x"
     - name: Install pypa/build
@@ -34,7 +34,7 @@ jobs:
     - name: Build a binary wheel and sdist
       run: python -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: python-package-distributions
         path: dist/
@@ -55,7 +55,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: python-package-distributions
         path: dist/
@@ -76,7 +76,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: python-package-distributions
         path: dist/
@@ -122,7 +122,7 @@ jobs:
 #
 #    steps:
 #    - name: Download all the dists
-#      uses: actions/download-artifact@v4
+#      uses: actions/download-artifact@v8
 #      with:
 #        name: python-package-distributions
 #        path: dist/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,10 @@ jobs:
         python-version: ['3.10']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -54,10 +54,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python 3.10
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
 


### PR DESCRIPTION
## Summary
- Upgrade all GitHub Actions to latest versions that support Node.js 24
- `actions/checkout` v4 → v6
- `actions/setup-python` v5 → v6
- `actions/upload-artifact` v4 → v7
- `actions/download-artifact` v4 → v8

Node.js 20 is deprecated and will be forced to Node.js 24 starting June 2nd, 2026. This eliminates the deprecation warnings on CI.

## Test plan
- [x] CI should pass without Node.js 20 deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only bumps to well-known GitHub Actions; main risk is unexpected behavior changes in the updated action releases affecting CI/release execution.
> 
> **Overview**
> Updates the CI and release GitHub Actions workflows to newer `actions/*` versions (e.g., `checkout`, `setup-python`, `upload-artifact`, `download-artifact`) to stay compatible with the upcoming Node.js 24 runner runtime.
> 
> No build/test logic changes were made; the workflows should behave the same while removing Node 20 deprecation warnings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c4513b53e6da79f10f4cbc1b0e10b80ef0cfe2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->