### PR TITLE
chore(ci): update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v3.0.0
+      uses: sigstore/gh-action-sigstore-python@v3.3.0
       with:
         inputs: >-
           ./dist/*.tar.gz


### PR DESCRIPTION
Bumps the one GitHub Actions dependency that was still behind its latest tag. Everything else (checkout@v6, setup-python@v6, upload-artifact@v7, download-artifact@v8) is already current on master after #45.

- `sigstore/gh-action-sigstore-python`: `v3.0.0` -> `v3.3.0`

Left as-is:
- `pypa/gh-action-pypi-publish@release/v1` (release-branch ref, not a version tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI dependency pin bump on the release signing job; no application or auth logic changes.
> 
> **Overview**
> Updates the **release** workflow’s Sigstore signing step to **`sigstore/gh-action-sigstore-python@v3.3.0`** (from `v3.0.0`). Inputs and the rest of the tag-release pipeline (artifact download, `gh release create`, upload signatures) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e00f825d2aa78de3a7c27282230ec02505bafc8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->